### PR TITLE
Add support to masking (redacting) URLs by a new "url" tag.

### DIFF
--- a/masker.go
+++ b/masker.go
@@ -4,6 +4,7 @@ package masker
 import (
 	"fmt"
 	"math"
+	"net/url"
 	"reflect"
 	"strings"
 )
@@ -23,6 +24,7 @@ const (
 	MID         mtype = "id"
 	MCreditCard mtype = "credit"
 	MStruct     mtype = "struct"
+	MURL        mtype = "url"
 )
 
 // Masker is a instance to marshal masked string
@@ -254,6 +256,8 @@ func (m *Masker) String(t mtype, i string) string {
 		return m.Telephone(i)
 	case MCreditCard:
 		return m.CreditCard(i)
+	case MURL:
+		return m.URL(i)
 	}
 }
 
@@ -418,6 +422,19 @@ func (m *Masker) Password(i string) string {
 		return ""
 	}
 	return strLoop(instance.mask, len("************"))
+}
+
+// URL mask the password part of the URL if exists
+//
+// Example:
+//   input: http://admin:mysecretpassword@localhost:1234/uri
+//   output:http://admin:xxxxx@localhost:1234/uri
+func (m *Masker) URL(i string) string {
+	u, err := url.Parse(i)
+	if err != nil {
+		return i
+	}
+	return u.Redacted()
 }
 
 // New create Masker

--- a/masker_test.go
+++ b/masker_test.go
@@ -1589,6 +1589,7 @@ func TestStruct(t *testing.T) {
 		Telephone  string `mask:"tel"`
 		Password   string `mask:"password"`
 		CreditCard string `mask:"credit"`
+		URL        string `mask:"url"`
 	}
 	type Boss struct {
 		Mobiles []string `mask:"mobile"`
@@ -1635,6 +1636,7 @@ func TestStruct(t *testing.T) {
 					Telephone:  "0227993078",
 					Password:   "abcde",
 					CreditCard: "1234567890987654",
+					URL:        "https://admin:secretpass@localhost:4321/uri",
 				},
 			},
 			want: &User{
@@ -1646,6 +1648,7 @@ func TestStruct(t *testing.T) {
 				Telephone:  "(02)2799-****",
 				Password:   "************",
 				CreditCard: "123456******7654",
+				URL:        "https://admin:xxxxx@localhost:4321/uri",
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
Hi there,

Thanks for building this! I've added a (simple) support for masking URL passwords using net/url.Redact().

Please let me know if there's anything else you need to merge this PR.