### PR TITLE
Fixed bug for platform compatibility.(eg:32/64bit cpu)

### DIFF
--- a/examples/gin-simple-log/go.mod
+++ b/examples/gin-simple-log/go.mod
@@ -6,3 +6,5 @@ require (
 	github.com/ggwhite/go-masker v1.0.4
 	github.com/gin-gonic/gin v1.7.4
 )
+
+replace github.com/ggwhite/go-masker => ../../../go-masker

--- a/examples/gin-simple-log/go.sum
+++ b/examples/gin-simple-log/go.sum
@@ -1,8 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/ggwhite/go-masker v1.0.4 h1:KkddCOxWi94yLP+V/Ts3qhn1AhfHu6TzMPT+eHLjIbQ=
-github.com/ggwhite/go-masker v1.0.4/go.mod h1:mz6t0JOqC12XvB/RSOAEsHHpLqJ+1iWxM3iHtl2Eofs=
+github.com/ggwhite/go-masker v1.0.6 h1:ljZ0Z9sYpvOXEZVjOFPPBPuUW1URIBBRu18f+AXXRJQ=
+github.com/ggwhite/go-masker v1.0.6/go.mod h1:PvCIa1zbmza5zXOk3G/SG9BR+q7EMT3KRzFIiXNxbDc=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.7.4 h1:QmUZXrvJ9qZ3GfWvQ+2wnW/1ePrTEJqPKMYEU3lD/DM=

--- a/masker.go
+++ b/masker.go
@@ -319,7 +319,7 @@ func (m *Masker) Address(i string) string {
 	if l <= 6 {
 		return strLoop(instance.mask, len("******"))
 	}
-	return m.overlay(i, strLoop(instance.mask, len("******")), 6, math.MaxInt64)
+	return m.overlay(i, strLoop(instance.mask, len("******")), 6, math.MaxInt)
 }
 
 // CreditCard mask 6 digits from the 7'th digit


### PR DESCRIPTION
It is better to make bitwidth decision by Golang at building, isn't it?

eg:
GOOS=linux GOARCH=arm GOARM=7 go build .

Using the fixed math.MaxInt64 would report following error:
$ GOOS=linux GOARCH=arm GOARM=6 go build .
# github.com/ggwhite/go-masker
/mnt/n03/gows/pkg/mod/github.com/ggwhite/go-masker@v1.0.6/masker.go:322:61: constant 9223372036854775807 overflows int
