### PR TITLE
Optimize split, since spliting zero string on zero string the only re…

### DIFF
--- a/masker.go
+++ b/masker.go
@@ -349,11 +349,7 @@ func (m *Masker) Email(i string) string {
 	}
 
 	tmp := strings.Split(i, "@")
-
-	switch len(tmp) {
-	case 0:
-		return ""
-	case 1:
+	if len(tmp) == 1 {
 		return m.overlay(i, strLoop(instance.mask, len("****")), 3, 7)
 	}
 


### PR DESCRIPTION
// If sep is empty, Split splits after each UTF-8 sequence. If both s
// and sep are empty, Split returns an empty slice.