### PR TITLE
Document the URL tag, and add a test case for a Postgresql URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ func main() {
 |ID          |MID          |id         |mask last 4 digits of ID number                                                                        |
 |CreditCard  |MCreditCard  |credit     |mask 6 digits from the 7'th digit                                                                      |
 |Struct      |MStruct      |struct     |mask the struct                                                                                        |
+|URL         |MURL         |url        |mask the password field if present, eg http://admin:mysecretpassword@localhost:1234/uri                |
 
 ## Mask the `String`
 

--- a/masker_test.go
+++ b/masker_test.go
@@ -1653,6 +1653,18 @@ func TestStruct(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "Postgres URL",
+			args: args{
+				s: &User{
+					URL: "postgres://username:mypass@localhost:5432/database_name",
+				},
+			},
+			want: &User{
+				URL: "postgres://username:xxxxx@localhost:5432/database_name",
+			},
+			wantErr: false,
+		},
+		{
 			name: "String Slice",
 			args: args{
 				s: &Boss{


### PR DESCRIPTION
I noticed that the README omitted the `url` tag value, so this PR adds that.
This also adds a test case for PostgreSQL urls, because my application relies on `go-masker` to redact them.
