### PR TITLE
Issue #21 - avoid panic by skipping unexported struct fields.

### DIFF
--- a/masker.go
+++ b/masker.go
@@ -125,6 +125,9 @@ func (m *Masker) Struct(s interface{}) (interface{}, error) {
 	}
 
 	for i := 0; i < selem.NumField(); i++ {
+		if !selem.Type().Field(i).IsExported() {
+			continue
+		}
 		mtag := selem.Type().Field(i).Tag.Get(tagName)
 		if len(mtag) == 0 {
 			tptr.Elem().Field(i).Set(selem.Field(i))

--- a/masker_test.go
+++ b/masker_test.go
@@ -1590,6 +1590,7 @@ func TestStruct(t *testing.T) {
 		Password   string `mask:"password"`
 		CreditCard string `mask:"credit"`
 		URL        string `mask:"url"`
+		unexported string
 	}
 	type Boss struct {
 		Mobiles []string `mask:"mobile"`
@@ -1637,6 +1638,7 @@ func TestStruct(t *testing.T) {
 					Password:   "abcde",
 					CreditCard: "1234567890987654",
 					URL:        "https://admin:secretpass@localhost:4321/uri",
+					unexported: "unexported",
 				},
 			},
 			want: &User{
@@ -1649,6 +1651,7 @@ func TestStruct(t *testing.T) {
 				Password:   "************",
 				CreditCard: "123456******7654",
 				URL:        "https://admin:xxxxx@localhost:4321/uri",
+				unexported: "",
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
Issue #21 reports a panic when masking a struct that has unexported fields, such as those generated by protobuf.
This fix simply skips unexported fields to avoid the panic. Unexported fields will have the zero value in the masked struct.
