### PR TITLE
fix: apply the email mask correctly

### DIFF
--- a/email.go
+++ b/email.go
@@ -24,7 +24,7 @@ func (m *EmailMasker) Marshal(s string, i string) string {
 	addr := tmp[0]
 	domain := tmp[1]
 
-	addr = overlay(addr, strLoop(s, 4), 3, 7)
+	addr = overlay(addr, strLoop(s, 4), 3, len(addr))
 
 	return addr + "@" + domain
 }

--- a/email_test.go
+++ b/email_test.go
@@ -27,7 +27,7 @@ func TestEmailMasker_Marshal(t *testing.T) {
 				s: "*",
 				i: "ggw.chang@gmail.com",
 			},
-			want: "ggw****ng@gmail.com",
+			want: "ggw****@gmail.com",
 		},
 		{
 			name: "Address Less Than 3",

--- a/masker_test.go
+++ b/masker_test.go
@@ -345,7 +345,7 @@ func TestMaskerMarshaler_Struct(t *testing.T) {
 					Email string `mask:"email"`
 				}{
 					Name:  "J**n D**e",
-					Email: "ggw****ng@gmail.com",
+					Email: "ggw****@gmail.com",
 				},
 			},
 		},


### PR DESCRIPTION
### Email Mask doesn't meet Its definition

The email masker definition says that "It keeps domain and the first 3 letters", and then gives an example of its use:

```go
// AddressMasker{}.Marshal("*", "ggw.chang@gmail.com") // returns "ggw****@gmail.com"
```
but in reality this returns:
`gg****ng@gmail.com`

I was testing this lib with some data from my application and larger emails weren't covered well:

Input: `christopher.jonathan@gmail.com`
Output: `chr****pher.jonathan@gmail.com`
When it should be: `chr****@gmail.com`

### Proposal

This pull request applies a fix so that the tag is applied to every email except the first 3 characters and your domain.