### PR TITLE
fix: return error instead of panic when Struct() receives non-struct input

### DIFF
--- a/masker.go
+++ b/masker.go
@@ -174,6 +174,14 @@ func (m *MaskerMarshaler) Struct(s interface{}) (interface{}, error) {
 
 	st := reflect.TypeOf(s)
 
+	actualKind := st.Kind()
+	if actualKind == reflect.Ptr {
+		actualKind = st.Elem().Kind()
+	}
+	if actualKind != reflect.Struct {
+		return nil, fmt.Errorf("input must be a struct or pointer to struct, got %v", actualKind)
+	}
+
 	if st.Kind() == reflect.Ptr {
 		tptr = reflect.New(st.Elem())
 		selem = reflect.ValueOf(s).Elem()

--- a/masker_test.go
+++ b/masker_test.go
@@ -368,6 +368,36 @@ func TestMaskerMarshaler_Struct(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "test struct with non-struct input returns error",
+			fields: fields{
+				Maskers: map[MaskerType]Masker{},
+				masker:  "*",
+			},
+			args:    args{s: "string input"},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "test struct with int input returns error",
+			fields: fields{
+				Maskers: map[MaskerType]Masker{},
+				masker:  "*",
+			},
+			args:    args{s: 42},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "test struct with pointer to non-struct returns error",
+			fields: fields{
+				Maskers: map[MaskerType]Masker{},
+				masker:  "*",
+			},
+			args:    args{s: func() *string { s := "hello"; return &s }()},
+			want:    nil,
+			wantErr: true,
+		},
+		{
 			name: "test struct with slice string",
 			fields: fields{
 				Maskers: map[MaskerType]Masker{


### PR DESCRIPTION
## Summary

- `Struct()` 傳入非 struct 型別（string、int、*string 等）時，原本會 panic，現在改回傳 error
- 新增測試案例：string、int、pointer to string 三種情境

Closes #29