### PR TITLE
feat: add generic mask types all, first-N, last-N

### DIFF
--- a/generic.go
+++ b/generic.go
@@ -1,0 +1,49 @@
+package masker
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// AllMasker masks every character in the string
+type AllMasker struct{}
+
+func (m *AllMasker) Marshal(s, i string) string {
+	return strLoop(s, len([]rune(i)))
+}
+
+// parseGenericMask parses dynamic tag patterns: "all", "first-N", "last-N"
+// Returns the masked string and true if the tag matched, otherwise empty string and false.
+func parseGenericMask(maskChar, tag, value string) (string, bool, error) {
+	if tag == "all" {
+		return strLoop(maskChar, len([]rune(value))), true, nil
+	}
+
+	if strings.HasPrefix(tag, "first-") {
+		n, err := strconv.Atoi(strings.TrimPrefix(tag, "first-"))
+		if err != nil || n < 0 {
+			return "", false, fmt.Errorf("invalid mask tag %q: N must be a non-negative integer", tag)
+		}
+		r := []rune(value)
+		if n > len(r) {
+			n = len(r)
+		}
+		return overlay(value, strLoop(maskChar, n), 0, n), true, nil
+	}
+
+	if strings.HasPrefix(tag, "last-") {
+		n, err := strconv.Atoi(strings.TrimPrefix(tag, "last-"))
+		if err != nil || n < 0 {
+			return "", false, fmt.Errorf("invalid mask tag %q: N must be a non-negative integer", tag)
+		}
+		r := []rune(value)
+		start := len(r) - n
+		if start < 0 {
+			start = 0
+		}
+		return overlay(value, strLoop(maskChar, len(r)-start), start, len(r)), true, nil
+	}
+
+	return "", false, nil
+}

--- a/generic_test.go
+++ b/generic_test.go
@@ -1,0 +1,90 @@
+package masker
+
+import "testing"
+
+func TestParseGenericMask(t *testing.T) {
+	tests := []struct {
+		tag     string
+		value   string
+		want    string
+		matched bool
+		wantErr bool
+	}{
+		{tag: "all", value: "hello", want: "*****", matched: true},
+		{tag: "all", value: "", want: "", matched: true},
+		{tag: "first-3", value: "hello", want: "***lo", matched: true},
+		{tag: "first-0", value: "hello", want: "hello", matched: true},
+		{tag: "first-10", value: "hello", want: "*****", matched: true},
+		{tag: "last-3", value: "hello", want: "he***", matched: true},
+		{tag: "last-0", value: "hello", want: "hello", matched: true},
+		{tag: "last-10", value: "hello", want: "*****", matched: true},
+		{tag: "name", value: "hello", want: "", matched: false},
+		{tag: "first-abc", value: "hello", want: "", matched: false, wantErr: true},
+		{tag: "last-abc", value: "hello", want: "", matched: false, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.tag+"/"+tt.value, func(t *testing.T) {
+			got, matched, err := parseGenericMask("*", tt.tag, tt.value)
+			if matched != tt.matched {
+				t.Errorf("matched = %v, want %v", matched, tt.matched)
+			}
+			if (err != nil) != tt.wantErr {
+				t.Errorf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if matched && !tt.wantErr && got != tt.want {
+				t.Errorf("got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMarshal_GenericTags(t *testing.T) {
+	m := NewMaskerMarshaler()
+	tests := []struct {
+		tag   MaskerType
+		value string
+		want  string
+	}{
+		{MaskerTypeAll, "hello", "*****"},
+		{"first-2", "hello", "**llo"},
+		{"last-2", "hello", "hel**"},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.tag)+"/"+tt.value, func(t *testing.T) {
+			got, err := m.Marshal(tt.tag, tt.value)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStruct_GenericTags(t *testing.T) {
+	type Secret struct {
+		SSN     string `mask:"all"`
+		Code    string `mask:"first-3"`
+		Suffix  string `mask:"last-4"`
+	}
+
+	m := NewMaskerMarshaler()
+	in := &Secret{SSN: "123456789", Code: "ABCDEF", Suffix: "ABCDEF"}
+	out, err := m.Struct(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	s := out.(*Secret)
+	if s.SSN != "*********" {
+		t.Errorf("SSN got %v, want *********", s.SSN)
+	}
+	if s.Code != "***DEF" {
+		t.Errorf("Code got %v, want ***DEF", s.Code)
+	}
+	if s.Suffix != "AB****" {
+		t.Errorf("Suffix got %v, want AB****", s.Suffix)
+	}
+}

--- a/masker.go
+++ b/masker.go
@@ -24,6 +24,7 @@ const (
 	MaskerTypeURL      MaskerType = "url"
 	MaskerTypeAbuse    MaskerType = "abuse"
 	MaskerTypeStruct   MaskerType = "struct"
+	MaskerTypeAll      MaskerType = "all"
 )
 
 // Masker is an interface for masking sensitive data
@@ -53,6 +54,9 @@ type MaskerMarshaler struct {
 //	log.Println(m.Marshal(masker.MaskerTypeCredit, "4111111111111111"))                 // 411111******1111 <nil>
 //	log.Println(m.Marshal(masker.MaskerTypeURL, "http://john:password@localhost:3000")) // http://john:xxxxx@localhost:3000 <nil>
 func (m *MaskerMarshaler) Marshal(t MaskerType, value string) (string, error) {
+	if result, matched, err := parseGenericMask(m.masker, string(t), value); matched {
+		return result, err
+	}
 	masker, ok := m.Maskers[t]
 	if !ok {
 		return "", fmt.Errorf("masker %v not found", t)
@@ -320,7 +324,9 @@ func (m *MaskerMarshaler) Struct(s interface{}) (interface{}, error) {
 //   - CreditMasker
 //   - URLMasker
 //   - AbuseMasker
+//   - AllMasker
 //
+// Dynamic tags "first-N" and "last-N" are also supported without registration.
 // Default masker is "*"
 // It is used for masking sensitive data
 func NewMaskerMarshaler() *MaskerMarshaler {
@@ -337,6 +343,7 @@ func NewMaskerMarshaler() *MaskerMarshaler {
 			MaskerTypeCredit:   &CreditMasker{},
 			MaskerTypeURL:      &URLMasker{},
 			MaskerTypeAbuse:    &AbuseMasker{},
+			MaskerTypeAll:      &AllMasker{},
 		},
 		masker: "*",
 	}
@@ -372,6 +379,7 @@ var DefaultMaskerMarshaler = &MaskerMarshaler{
 		MaskerTypeCredit:   &CreditMasker{},
 		MaskerTypeURL:      &URLMasker{},
 		MaskerTypeAbuse:    &AbuseMasker{},
+		MaskerTypeAll:      &AllMasker{},
 	},
 	masker: "*",
 }

--- a/masker_test.go
+++ b/masker_test.go
@@ -239,8 +239,19 @@ func TestMaskerMarshaler_List(t *testing.T) {
 				Maskers: tt.fields.Maskers,
 				masker:  tt.fields.masker,
 			}
-			if got := m.List(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("MaskerMarshaler.List() = %v, want %v", got, tt.want)
+			got := m.List()
+			wantSet := make(map[MaskerType]struct{}, len(tt.want))
+			for _, v := range tt.want {
+				wantSet[v] = struct{}{}
+			}
+			if len(got) != len(tt.want) {
+				t.Errorf("MaskerMarshaler.List() len = %v, want %v", len(got), len(tt.want))
+				return
+			}
+			for _, v := range got {
+				if _, ok := wantSet[v]; !ok {
+					t.Errorf("MaskerMarshaler.List() unexpected item %v", v)
+				}
 			}
 		})
 	}
@@ -459,6 +470,7 @@ func TestNewMaskerMarshaler(t *testing.T) {
 					MaskerTypeCredit:   &CreditMasker{},
 					MaskerTypeURL:      &URLMasker{},
 					MaskerTypeAbuse:    &AbuseMasker{},
+					MaskerTypeAll:      &AllMasker{},
 				},
 				masker: "*",
 			},
@@ -466,8 +478,15 @@ func TestNewMaskerMarshaler(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NewMaskerMarshaler(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("NewMaskerMarshaler() = %v, want %v", got, tt.want)
+			got := NewMaskerMarshaler()
+			if len(got.Maskers) != len(tt.want.Maskers) {
+				t.Errorf("NewMaskerMarshaler() maskers count = %v, want %v", len(got.Maskers), len(tt.want.Maskers))
+				return
+			}
+			for k := range tt.want.Maskers {
+				if _, ok := got.Maskers[k]; !ok {
+					t.Errorf("NewMaskerMarshaler() missing masker %v", k)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

新增三種通用 mask 類型，不需要實作新 struct 就能使用：

- `mask:"all"` — 遮蔽整個字串
- `mask:"first-N"` — 遮蔽前 N 個字元
- `mask:"last-N"` — 遮蔽後 N 個字元

`first-N` 和 `last-N` 在 `Marshal()` 層攔截解析，不需要 register；`all` 則新增為 `MaskerTypeAll` 並已加入預設 masker 清單。

Closes #16