### PR TITLE
feat(#issue37): implements `mapstruct` tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,20 @@
 
 Go Masker v2 is a simple and extensible library for masking sensitive data in Go structs. Use struct tags to control how fields are masked — passwords, emails, IDs, credit cards, and more.
 
-* [Install](#install)
-* [Quick Start](#quick-start)
-* [Masker Types](#masker-types)
-* [Custom Mask Character](#custom-mask-character)
-* [Abuse Masker](#abuse-masker)
-* [Custom Masker](#custom-masker)
-* [Contributors](#contributors)
+- [Go Masker v2](#go-masker-v2)
+  - [Install](#install)
+  - [Quick Start](#quick-start)
+  - [Masker Types](#masker-types)
+    - [Masking Slices](#masking-slices)
+    - [Masking Nested Structs](#masking-nested-structs)
+    - [Masking Maps](#masking-maps)
+  - [Custom Mask Character](#custom-mask-character)
+  - [Abuse Masker](#abuse-masker)
+    - [Basic Usage](#basic-usage)
+    - [Load Words from File](#load-words-from-file)
+    - [Use with Struct Tags](#use-with-struct-tags)
+  - [Custom Masker](#custom-masker)
+  - [Contributors](#contributors)
 
 ## Install
 
@@ -64,20 +71,21 @@ masked, err := masker.DefaultMaskerMarshaler.Struct(u)
 
 ## Masker Types
 
-| Tag | Description | Example Input | Example Output |
-|-----|-------------|---------------|----------------|
-| `none` | No masking, return as-is | `foo` | `foo` |
-| `password` | Always returns 14 asterisks | `secret` | `**************` |
-| `name` | Masks middle characters | `John Doe` | `J**n D**e` |
-| `addr` | Masks last 6 characters | `台北市內湖區內湖路一段737巷1號` | `台北市內湖區內湖路一段7******` |
-| `email` | Keeps first 3 chars and domain | `john@gmail.com` | `joh****@gmail.com` |
-| `mobile` | Masks 3 digits from 4th position | `0987654321` | `0987***321` |
-| `tel` | Formats and masks last 4 digits | `0227993078` | `(02)2799-****` |
-| `id` | Masks digits 7–10 | `A123456789` | `A12345****` |
-| `credit` | Masks digits 7–12 | `4111111111111111` | `411111******1111` |
-| `url` | Masks URL password | `http://user:pass@host` | `http://user:xxxxx@host` |
-| `abuse` | Masks abusive words via trie | `bad word` | `*** word` |
-| `struct` | Recursively masks nested struct | — | — |
+| Tag         | Description                                                                                                | Example Input                    | Example Output                  |
+| ----------- | ---------------------------------------------------------------------------------------------------------- | -------------------------------- | ------------------------------- |
+| `none`      | No masking, return as-is                                                                                   | `foo`                            | `foo`                           |
+| `password`  | Always returns 14 asterisks                                                                                | `secret`                         | `**************`                |
+| `name`      | Masks middle characters                                                                                    | `John Doe`                       | `J**n D**e`                     |
+| `addr`      | Masks last 6 characters                                                                                    | `台北市內湖區內湖路一段737巷1號` | `台北市內湖區內湖路一段7******` |
+| `email`     | Keeps first 3 chars and domain                                                                             | `john@gmail.com`                 | `joh****@gmail.com`             |
+| `mobile`    | Masks 3 digits from 4th position                                                                           | `0987654321`                     | `0987***321`                    |
+| `tel`       | Formats and masks last 4 digits                                                                            | `0227993078`                     | `(02)2799-****`                 |
+| `id`        | Masks digits 7–10                                                                                          | `A123456789`                     | `A12345****`                    |
+| `credit`    | Masks digits 7–12                                                                                          | `4111111111111111`               | `411111******1111`              |
+| `url`       | Masks URL password                                                                                         | `http://user:pass@host`          | `http://user:xxxxx@host`        |
+| `abuse`     | Masks abusive words via trie                                                                               | `bad word`                       | `*** word`                      |
+| `struct`    | Recursively masks nested struct                                                                            | —                                | —                               |
+| `mapstruct` | Recursively masks map values (supports nested maps, structs, pointers, slices, and pointer-to-slice forms) | —                                | —                               |
 
 ### Masking Slices
 
@@ -100,6 +108,60 @@ type User struct {
     Name    string  `mask:"name"`
     Address Address `mask:"struct"`
 }
+```
+
+### Masking Maps
+
+Use `mask:"mapstruct"` on map fields to recursively mask map values.
+
+`mapstruct` tag limitations and rules:
+
+- Works only on fields whose own tag is exactly `mask:"mapstruct"`.
+- Recursion applies to map **values** only; map keys are never masked.
+- Recurses through `map`, `struct`, `ptr`, and `slice` combinations (including nested map and pointer-to-slice forms).
+- Leaf values that are not struct-like (for example `string`, `int`, `bool`, `time.Time` fields without mask tags) are kept as-is.
+- `nil` values are preserved (`nil` map, `nil` pointer, `nil` slice).
+- Struct masking still follows normal struct-tag rules: only exported fields are processed, and fields without `mask:"..."` stay unchanged.
+- `interface{}` map values are not force-unwrapped by `mapstruct`; if you need masking, prefer concrete types.
+- Cyclic object graphs are not specially handled; avoid self-referencing structures in recursive masking paths.
+
+```go
+type Item struct {
+    ID string `mask:"id"`
+}
+
+type Payload struct {
+    Items      map[int]Item                      `mask:"mapstruct"`
+    Ptrs       map[int]*Item                     `mask:"mapstruct"`
+    SliceItems map[int][]Item                    `mask:"mapstruct"`
+    PtrSlices  map[int]*[]Item                   `mask:"mapstruct"`
+    Nested     map[int]map[string]map[int][]Item `mask:"mapstruct"`
+}
+
+m := masker.NewMaskerMarshaler()
+masked, _ := m.Struct(Payload{
+    Items:      map[int]Item{1: {ID: "A123456789"}},
+    Ptrs:       map[int]*Item{1: {ID: "A123456789"}, 2: nil},
+    SliceItems: map[int][]Item{1: {{ID: "A123456789"}, {ID: "B223456789"}}},
+    PtrSlices: func() map[int]*[]Item {
+        x := []Item{{ID: "A123456789"}, {ID: "B223456789"}}
+        return map[int]*[]Item{1: &x, 2: nil}
+    }(),
+    Nested: map[int]map[string]map[int][]Item{
+        1: {
+            "group": {
+                10: {{ID: "C323456789"}},
+            },
+        },
+    },
+})
+// Items[1].ID => A12345****
+// Ptrs[1].ID  => A12345****
+// Ptrs[2]     => nil
+// SliceItems[1][0].ID => A12345****
+// PtrSlices[1][1].ID  => B22345****
+// PtrSlices[2]        => nil
+// Nested[1]["group"][10][0].ID => C32345****
 ```
 
 ## Custom Mask Character

--- a/masker.go
+++ b/masker.go
@@ -12,19 +12,20 @@ type MaskerType string
 
 // MaskerType constants
 const (
-	MaskerTypeNone     MaskerType = "none"
-	MaskerTypePassword MaskerType = "password"
-	MaskerTypeName     MaskerType = "name"
-	MaskerTypeAddress  MaskerType = "addr"
-	MaskerTypeEmail    MaskerType = "email"
-	MaskerTypeMobile   MaskerType = "mobile"
-	MaskerTypeTel      MaskerType = "tel"
-	MaskerTypeID       MaskerType = "id"
-	MaskerTypeCredit   MaskerType = "credit"
-	MaskerTypeURL      MaskerType = "url"
-	MaskerTypeAbuse    MaskerType = "abuse"
-	MaskerTypeStruct   MaskerType = "struct"
-	MaskerTypeAll      MaskerType = "all"
+	MaskerTypeNone      MaskerType = "none"
+	MaskerTypePassword  MaskerType = "password"
+	MaskerTypeName      MaskerType = "name"
+	MaskerTypeAddress   MaskerType = "addr"
+	MaskerTypeEmail     MaskerType = "email"
+	MaskerTypeMobile    MaskerType = "mobile"
+	MaskerTypeTel       MaskerType = "tel"
+	MaskerTypeID        MaskerType = "id"
+	MaskerTypeCredit    MaskerType = "credit"
+	MaskerTypeURL       MaskerType = "url"
+	MaskerTypeAbuse     MaskerType = "abuse"
+	MaskerTypeStruct    MaskerType = "struct"
+	MaskerTypeAll       MaskerType = "all"
+	MaskerTypeMapStruct MaskerType = "mapstruct"
 )
 
 // Masker is an interface for masking sensitive data
@@ -121,6 +122,11 @@ func (m *MaskerMarshaler) SetMasker(masker string) {
 
 // Struct must input a interface{}, add tag mask on struct fields, after Struct(), return a pointer interface{} of input type and it will be masked with the tag format type
 //
+// Limitation:
+//   - Cyclic object graphs are not specially handled. Self-referencing structures can
+//     recurse indefinitely when using `mask:"struct"` or `mask:"mapstruct"`.
+//   - Avoid cyclic references in masking paths.
+//
 // Example:
 //
 //	type Foo struct {
@@ -203,6 +209,7 @@ func (m *MaskerMarshaler) Struct(s interface{}) (interface{}, error) {
 			tptr.Elem().Field(i).Set(selem.Field(i))
 			continue
 		}
+
 		switch selem.Field(i).Type().Kind() {
 		default:
 			tptr.Elem().Field(i).Set(selem.Field(i))
@@ -231,11 +238,35 @@ func (m *MaskerMarshaler) Struct(s interface{}) (interface{}, error) {
 				}
 				tptr.Elem().Field(i).Set(reflect.ValueOf(_t))
 			}
+		case reflect.Map:
+			if selem.Field(i).IsNil() {
+				continue
+			}
+			if MaskerType(mtag) != MaskerTypeMapStruct {
+				tptr.Elem().Field(i).Set(selem.Field(i))
+				continue
+			}
+
+			maskedMap := reflect.MakeMapWithSize(selem.Field(i).Type(), selem.Field(i).Len())
+			iter := selem.Field(i).MapRange()
+			for iter.Next() {
+				v := iter.Value()
+				maskedValue, err := m.maskMapStructValue(v)
+				if err != nil {
+					return nil, err
+				}
+
+				maskedMap.SetMapIndex(iter.Key(), maskedValue)
+			}
+			tptr.Elem().Field(i).Set(maskedMap)
+			continue
+
 		case reflect.Slice:
 			if selem.Field(i).IsNil() {
 				continue
 			}
-			if selem.Field(i).Type().Elem().Kind() == reflect.String {
+			switch {
+			case selem.Field(i).Type().Elem().Kind() == reflect.String:
 				orgval := selem.Field(i).Interface().([]string)
 				newval := make([]string, len(orgval))
 				for i, val := range selem.Field(i).Interface().([]string) {
@@ -246,9 +277,7 @@ func (m *MaskerMarshaler) Struct(s interface{}) (interface{}, error) {
 					newval[i] = v
 				}
 				tptr.Elem().Field(i).Set(reflect.ValueOf(newval))
-				continue
-			}
-			if selem.Field(i).Type().Elem().Kind() == reflect.Struct && MaskerType(mtag) == MaskerTypeStruct {
+			case selem.Field(i).Type().Elem().Kind() == reflect.Struct && MaskerType(mtag) == MaskerTypeStruct:
 				newval := reflect.MakeSlice(selem.Field(i).Type(), 0, selem.Field(i).Len())
 				for j, l := 0, selem.Field(i).Len(); j < l; j++ {
 					_n, err := m.Struct(selem.Field(i).Index(j).Interface())
@@ -258,9 +287,7 @@ func (m *MaskerMarshaler) Struct(s interface{}) (interface{}, error) {
 					newval = reflect.Append(newval, reflect.ValueOf(_n).Elem())
 				}
 				tptr.Elem().Field(i).Set(newval)
-				continue
-			}
-			if selem.Field(i).Type().Elem().Kind() == reflect.Ptr && MaskerType(mtag) == MaskerTypeStruct {
+			case selem.Field(i).Type().Elem().Kind() == reflect.Ptr && MaskerType(mtag) == MaskerTypeStruct:
 				newval := reflect.MakeSlice(selem.Field(i).Type(), 0, selem.Field(i).Len())
 				for j, l := 0, selem.Field(i).Len(); j < l; j++ {
 					_n, err := m.Struct(selem.Field(i).Index(j).Interface())
@@ -270,9 +297,7 @@ func (m *MaskerMarshaler) Struct(s interface{}) (interface{}, error) {
 					newval = reflect.Append(newval, reflect.ValueOf(_n))
 				}
 				tptr.Elem().Field(i).Set(newval)
-				continue
-			}
-			if selem.Field(i).Type().Elem().Kind() == reflect.Interface && MaskerType(mtag) == MaskerTypeStruct {
+			case selem.Field(i).Type().Elem().Kind() == reflect.Interface && MaskerType(mtag) == MaskerTypeStruct:
 				newval := reflect.MakeSlice(selem.Field(i).Type(), 0, selem.Field(i).Len())
 				for j, l := 0, selem.Field(i).Len(); j < l; j++ {
 					_n, err := m.Struct(selem.Field(i).Index(j).Interface())
@@ -286,7 +311,6 @@ func (m *MaskerMarshaler) Struct(s interface{}) (interface{}, error) {
 					}
 				}
 				tptr.Elem().Field(i).Set(newval)
-				continue
 			}
 		case reflect.Interface:
 			if selem.Field(i).IsNil() {
@@ -308,6 +332,60 @@ func (m *MaskerMarshaler) Struct(s interface{}) (interface{}, error) {
 	}
 
 	return tptr.Interface(), nil
+}
+
+// maskMapStructValue recursively masks mapstruct values for struct, ptr, and slice shapes.
+// Unsupported scalar/container leaf values are returned as-is to preserve original data.
+// Note: cyclic object graphs are not handled and may cause a stack overflow.
+func (m *MaskerMarshaler) maskMapStructValue(v reflect.Value) (reflect.Value, error) {
+	switch v.Kind() {
+	case reflect.Map:
+		if v.IsNil() {
+			return v, nil
+		}
+		maskedMap := reflect.MakeMapWithSize(v.Type(), v.Len())
+		iter := v.MapRange()
+		for iter.Next() {
+			maskedValue, err := m.maskMapStructValue(iter.Value())
+			if err != nil {
+				return reflect.Value{}, err
+			}
+			maskedMap.SetMapIndex(iter.Key(), maskedValue)
+		}
+		return maskedMap, nil
+	case reflect.Struct:
+		nextValue, err := m.Struct(v.Interface())
+		if err != nil {
+			return reflect.Value{}, err
+		}
+		return reflect.ValueOf(nextValue).Elem(), nil
+	case reflect.Ptr:
+		if v.IsNil() {
+			return v, nil
+		}
+		maskedElem, err := m.maskMapStructValue(v.Elem())
+		if err != nil {
+			return reflect.Value{}, err
+		}
+		maskedPtr := reflect.New(v.Elem().Type())
+		maskedPtr.Elem().Set(maskedElem)
+		return maskedPtr, nil
+	case reflect.Slice:
+		if v.IsNil() {
+			return v, nil
+		}
+		maskedSlice := reflect.MakeSlice(v.Type(), 0, v.Len())
+		for i := 0; i < v.Len(); i++ {
+			maskedElem, err := m.maskMapStructValue(v.Index(i))
+			if err != nil {
+				return reflect.Value{}, err
+			}
+			maskedSlice = reflect.Append(maskedSlice, maskedElem)
+		}
+		return maskedSlice, nil
+	default:
+		return v, nil
+	}
 }
 
 // NewMaskerMarshaler returns a new masker marshaler

--- a/masker_test.go
+++ b/masker_test.go
@@ -551,3 +551,232 @@ func Test_overlay(t *testing.T) {
 		})
 	}
 }
+
+func TestMaskerMarshaler_MapStructs(t *testing.T) {
+	type item struct {
+		ID string `mask:"id"`
+	}
+
+	tests := []struct {
+		name string
+		in   interface{}
+		want interface{}
+	}{
+		{
+			name: "map struct with mapstruct tag",
+			in: struct {
+				Items map[int]item `mask:"mapstruct"`
+			}{
+				Items: map[int]item{1: {ID: "A123456789"}},
+			},
+			want: &struct {
+				Items map[int]item `mask:"mapstruct"`
+			}{
+				Items: map[int]item{1: {ID: "A12345****"}},
+			},
+		},
+		{
+			name: "nil map",
+			in: struct {
+				Items map[int]item `mask:"mapstruct"`
+			}{
+				Items: nil,
+			},
+			want: &struct {
+				Items map[int]item `mask:"mapstruct"`
+			}{
+				Items: nil,
+			},
+		},
+		{
+			name: "empty non-nil map",
+			in: struct {
+				Items map[int]item `mask:"mapstruct"`
+			}{Items: map[int]item{}},
+			want: &struct {
+				Items map[int]item `mask:"mapstruct"`
+			}{Items: map[int]item{}},
+		},
+		{
+			name: "map without mapstruct tag",
+			in: struct {
+				Items map[int]item `mask:"struct"`
+			}{
+				Items: map[int]item{1: {ID: "A123456789"}},
+			},
+			want: &struct {
+				Items map[int]item `mask:"struct"`
+			}{
+				Items: map[int]item{1: {ID: "A123456789"}},
+			},
+		},
+		{
+			name: "map with scalar values passes through unchanged",
+			in: struct {
+				Items map[string]string `mask:"mapstruct"`
+			}{Items: map[string]string{"key": "value"}},
+			want: &struct {
+				Items map[string]string `mask:"mapstruct"`
+			}{Items: map[string]string{"key": "value"}},
+		},
+		{
+			name: "map pointer values",
+			in: struct {
+				Items map[int]*item `mask:"mapstruct"`
+			}{
+				Items: map[int]*item{
+					1: {ID: "A123456789"},
+					2: nil,
+				},
+			},
+			want: &struct {
+				Items map[int]*item `mask:"mapstruct"`
+			}{
+				Items: map[int]*item{
+					1: {ID: "A12345****"},
+					2: nil,
+				},
+			},
+		},
+		{
+			name: "map slice values",
+			in: struct {
+				Items map[int][]item `mask:"mapstruct"`
+			}{
+				Items: map[int][]item{
+					1: {{ID: "A123456789"}, {ID: "B223456789"}},
+					2: {{ID: "C323456789"}},
+				},
+			},
+			want: &struct {
+				Items map[int][]item `mask:"mapstruct"`
+			}{
+				Items: map[int][]item{
+					1: {{ID: "A12345****"}, {ID: "B22345****"}},
+					2: {{ID: "C32345****"}},
+				},
+			},
+		},
+		{
+			name: "nil map slice values",
+			in: struct {
+				Items map[int][]item `mask:"mapstruct"`
+			}{
+				Items: nil,
+			},
+			want: &struct {
+				Items map[int][]item `mask:"mapstruct"`
+			}{
+				Items: nil,
+			},
+		},
+		{
+			name: "map pointer to slice values",
+			in: func() interface{} {
+				items := []item{{ID: "A123456789"}, {ID: "B223456789"}}
+				return struct {
+					Items map[int]*[]item `mask:"mapstruct"`
+				}{
+					Items: map[int]*[]item{
+						1: &items,
+						2: nil,
+					},
+				}
+			}(),
+			want: func() interface{} {
+				items := []item{{ID: "A12345****"}, {ID: "B22345****"}}
+				return &struct {
+					Items map[int]*[]item `mask:"mapstruct"`
+				}{
+					Items: map[int]*[]item{
+						1: &items,
+						2: nil,
+					},
+				}
+			}(),
+		},
+		{
+			name: "map of map with slice values",
+			in: struct {
+				Items map[int]map[int][]item `mask:"mapstruct"`
+			}{
+				Items: map[int]map[int][]item{
+					1: {
+						10: {{ID: "A123456789"}, {ID: "B223456789"}},
+						11: nil,
+					},
+					2: nil,
+				},
+			},
+			want: &struct {
+				Items map[int]map[int][]item `mask:"mapstruct"`
+			}{
+				Items: map[int]map[int][]item{
+					1: {
+						10: {{ID: "A12345****"}, {ID: "B22345****"}},
+						11: nil,
+					},
+					2: nil,
+				},
+			},
+		},
+		{
+			name: "multi-level map with pointer slice leaves",
+			in: func() interface{} {
+				a := []item{{ID: "A123456789"}}
+				b := []item{{ID: "B223456789"}, {ID: "C323456789"}}
+				return struct {
+					Items map[int]map[string]map[int]*[]item `mask:"mapstruct"`
+				}{
+					Items: map[int]map[string]map[int]*[]item{
+						1: {
+							"x": {
+								100: &a,
+								101: nil,
+							},
+						},
+						2: {
+							"y": {
+								200: &b,
+							},
+						},
+					},
+				}
+			}(),
+			want: func() interface{} {
+				a := []item{{ID: "A12345****"}}
+				b := []item{{ID: "B22345****"}, {ID: "C32345****"}}
+				return &struct {
+					Items map[int]map[string]map[int]*[]item `mask:"mapstruct"`
+				}{
+					Items: map[int]map[string]map[int]*[]item{
+						1: {
+							"x": {
+								100: &a,
+								101: nil,
+							},
+						},
+						2: {
+							"y": {
+								200: &b,
+							},
+						},
+					},
+				}
+			}(),
+		},
+	}
+
+	m := NewMaskerMarshaler()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := m.Struct(tt.in)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("MaskerMarshaler.Struct() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Add support for recursive masking on map values with `mask:"map_struct"`.

## What Changed
- Added new tag type: `map_struct`
- Updated `Struct()` map handling to:
  - recursively mask map values for `struct` and `*struct`
  - keep nil maps and nil pointer values safe
  - skip recursive masking when tag is not `map_struct`
- Added/updated tests for map masking scenarios (table-driven)
- Updated README with `map_struct` docs and examples

## Validation
- `go test ./... -run TestMaskerMarshaler_MapStructs -v`
<img width="1125" height="203" alt="image" src="https://github.com/user-attachments/assets/83f7d72d-e0e7-40b1-b174-669d89a9c4e4" />

- `go test ./...`
<img width="916" height="41" alt="image" src="https://github.com/user-attachments/assets/a234f5ca-b456-4169-991b-6a3a365ac2de" />


## Compatibility
Backward compatible. New behavior is only applied when `mask:"map_struct"` is used.

## Related
Closes #37
